### PR TITLE
Don't delete branches after merging

### DIFF
--- a/src/AutoMerge/github.jl
+++ b/src/AutoMerge/github.jl
@@ -159,13 +159,13 @@ function merge!(registry_repo::GitHub.Repo,
         Base.show_backtrace(stderr, catch_backtrace())
         println(stderr)
     end
-    try
-        delete_merged_branch!(registry_repo, pr; auth=auth)
-    catch ex
-        showerror(stderr, ex)
-        Base.show_backtrace(stderr, catch_backtrace())
-        println(stderr)
-    end
+#     try
+#         delete_merged_branch!(registry_repo, pr; auth=auth)
+#     catch ex
+#         showerror(stderr, ex)
+#         Base.show_backtrace(stderr, catch_backtrace())
+#         println(stderr)
+#     end
     return nothing
 end
 


### PR DESCRIPTION
The General registry is already configured to automatically delete merged branches. Therefore, we don't need to also do that in the automerge code.

cc: @fredrikekre 